### PR TITLE
LSE max wait patches

### DIFF
--- a/os/hal/ports/STM32/STM32F0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F0xx/hal_lld.c
@@ -68,6 +68,7 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
+  int rusefiLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -75,8 +76,10 @@ static void hal_lld_backup_domain_init(void) {
   /* No LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
-  while ((RCC->BDCR & RCC_BDCR_LSERDY) == 0)
-    ;                                     /* Waits until LSE is stable.   */
+  /* Waits until LSE is stable or times out. */
+  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+      && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
+    ;
 #endif
 
 #if STM32_RTCSEL != STM32_RTCSEL_NOCLOCK
@@ -84,7 +87,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+#if STM32_LSE_ENABLED
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+#else
     RCC->BDCR |= STM32_RTCSEL;
+#endif
 
     /* RTC clock enabled.*/
     RCC->BDCR |= RCC_BDCR_RTCEN;

--- a/os/hal/ports/STM32/STM32F0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F0xx/hal_lld.c
@@ -68,7 +68,7 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -77,7 +77,7 @@ static void hal_lld_backup_domain_init(void) {
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
   /* Waits until LSE is stable or times out. */
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
     ;
 #endif
@@ -88,7 +88,7 @@ static void hal_lld_backup_domain_init(void) {
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F0xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F0xx/hal_lld.h
@@ -377,6 +377,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   Main clock source selection.
  * @note    If the selected clock source is not the PLL then the PLL is not
  *          initialized and started.

--- a/os/hal/ports/STM32/STM32F0xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F0xx/hal_lld.h
@@ -379,20 +379,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32F1xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F1xx/hal_lld.c
@@ -66,6 +66,7 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
+  int rusefiLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -73,8 +74,10 @@ static void hal_lld_backup_domain_init(void) {
   /* No LSE Bypass.*/
   RCC->BDCR |= RCC_BDCR_LSEON;
 #endif
-  while ((RCC->BDCR & RCC_BDCR_LSERDY) == 0)
-    ;                                     /* Waits until LSE is stable.   */
+  /* Waits until LSE is stable or times out. */
+  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+      && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
+    ;
 #endif /* STM32_LSE_ENABLED */
 
 #if STM32_RTCSEL != STM32_RTCSEL_NOCLOCK
@@ -82,7 +85,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+#if STM32_LSE_ENABLED
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+#else
     RCC->BDCR |= STM32_RTCSEL;
+#endif
 
     /* Prescaler value loaded in registers.*/
     rtc_lld_set_prescaler();

--- a/os/hal/ports/STM32/STM32F1xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F1xx/hal_lld.c
@@ -66,7 +66,7 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -75,7 +75,7 @@ static void hal_lld_backup_domain_init(void) {
   RCC->BDCR |= RCC_BDCR_LSEON;
 #endif
   /* Waits until LSE is stable or times out. */
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
     ;
 #endif /* STM32_LSE_ENABLED */
@@ -86,7 +86,7 @@ static void hal_lld_backup_domain_init(void) {
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F1xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F1xx/hal_lld.h
@@ -177,6 +177,25 @@
 #if !defined(STM32_LSE_ENABLED) || defined(__DOXYGEN__)
 #define STM32_LSE_ENABLED           FALSE
 #endif
+
+/**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
 /** @} */
 
 /*===========================================================================*/

--- a/os/hal/ports/STM32/STM32F1xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F1xx/hal_lld.h
@@ -181,20 +181,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 /** @} */
 

--- a/os/hal/ports/STM32/STM32F37x/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F37x/hal_lld.c
@@ -65,6 +65,7 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
+  int rusefiLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -72,8 +73,10 @@ static void hal_lld_backup_domain_init(void) {
   /* No LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
-  while ((RCC->BDCR & RCC_BDCR_LSERDY) == 0)
-    ;                                     /* Waits until LSE is stable.   */
+  /* Waits until LSE is stable or times out. */
+  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+      && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
+    ;
 #endif
 
 #if STM32_RTCSEL != STM32_RTCSEL_NOCLOCK
@@ -81,7 +84,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+#if STM32_LSE_ENABLED
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+#else
     RCC->BDCR |= STM32_RTCSEL;
+#endif
 
     /* RTC clock enabled.*/
     RCC->BDCR |= RCC_BDCR_RTCEN;

--- a/os/hal/ports/STM32/STM32F37x/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F37x/hal_lld.c
@@ -65,7 +65,7 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -74,7 +74,7 @@ static void hal_lld_backup_domain_init(void) {
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
   /* Waits until LSE is stable or times out. */
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
     ;
 #endif
@@ -85,7 +85,7 @@ static void hal_lld_backup_domain_init(void) {
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F37x/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F37x/hal_lld.h
@@ -348,6 +348,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   Main clock source selection.
  * @note    If the selected clock source is not the PLL then the PLL is not
  *          initialized and started.

--- a/os/hal/ports/STM32/STM32F37x/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F37x/hal_lld.h
@@ -350,20 +350,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32F3xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F3xx/hal_lld.c
@@ -65,6 +65,7 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
+  int rusefiLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -72,8 +73,10 @@ static void hal_lld_backup_domain_init(void) {
   /* No LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
-  while ((RCC->BDCR & RCC_BDCR_LSERDY) == 0)
-    ;                                     /* Waits until LSE is stable.   */
+  /* Waits until LSE is stable or times out. */
+  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+      && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
+    ;
 #endif
 
 #if STM32_RTCSEL != STM32_RTCSEL_NOCLOCK
@@ -81,7 +84,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+#if STM32_LSE_ENABLED
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+#else
     RCC->BDCR |= STM32_RTCSEL;
+#endif
 
     /* RTC clock enabled.*/
     RCC->BDCR |= RCC_BDCR_RTCEN;

--- a/os/hal/ports/STM32/STM32F3xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F3xx/hal_lld.c
@@ -65,7 +65,7 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -74,7 +74,7 @@ static void hal_lld_backup_domain_init(void) {
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
   /* Waits until LSE is stable or times out. */
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
     ;
 #endif
@@ -85,7 +85,7 @@ static void hal_lld_backup_domain_init(void) {
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F3xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F3xx/hal_lld.h
@@ -388,6 +388,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   Main clock source selection.
  * @note    If the selected clock source is not the PLL then the PLL is not
  *          initialized and started.

--- a/os/hal/ports/STM32/STM32F3xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F3xx/hal_lld.h
@@ -390,20 +390,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32F4xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F4xx/hal_lld.c
@@ -64,6 +64,7 @@ static void hal_lld_backup_domain_init(void) {
   }
 
 #if STM32_LSE_ENABLED
+  int rusefiLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -71,8 +72,10 @@ static void hal_lld_backup_domain_init(void) {
   /* No LSE Bypass.*/
   RCC->BDCR |= RCC_BDCR_LSEON;
 #endif
-  while ((RCC->BDCR & RCC_BDCR_LSERDY) == 0)
-    ;                                       /* Waits until LSE is stable.   */
+  /* Waits until LSE is stable or times out. */
+  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+      && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
+    ;
 #endif
 
 #if HAL_USE_RTC
@@ -80,7 +83,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+#if STM32_LSE_ENABLED
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+#else
     RCC->BDCR |= STM32_RTCSEL;
+#endif
 
     /* RTC clock enabled.*/
     RCC->BDCR |= RCC_BDCR_RTCEN;

--- a/os/hal/ports/STM32/STM32F4xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F4xx/hal_lld.c
@@ -64,7 +64,7 @@ static void hal_lld_backup_domain_init(void) {
   }
 
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -73,7 +73,7 @@ static void hal_lld_backup_domain_init(void) {
   RCC->BDCR |= RCC_BDCR_LSEON;
 #endif
   /* Waits until LSE is stable or times out. */
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
     ;
 #endif
@@ -84,7 +84,7 @@ static void hal_lld_backup_domain_init(void) {
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F4xx/hal_lld_type1.h
+++ b/os/hal/ports/STM32/STM32F4xx/hal_lld_type1.h
@@ -621,6 +621,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   USB/SDIO clock setting.
  */
 #if !defined(STM32_CLOCK48_REQUIRED) || defined(__DOXYGEN__)

--- a/os/hal/ports/STM32/STM32F4xx/hal_lld_type1.h
+++ b/os/hal/ports/STM32/STM32F4xx/hal_lld_type1.h
@@ -623,20 +623,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32F4xx/hal_lld_type2.h
+++ b/os/hal/ports/STM32/STM32F4xx/hal_lld_type2.h
@@ -403,6 +403,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   USB/SDIO clock setting.
  */
 #if !defined(STM32_CLOCK48_REQUIRED) || defined(__DOXYGEN__)

--- a/os/hal/ports/STM32/STM32F4xx/hal_lld_type2.h
+++ b/os/hal/ports/STM32/STM32F4xx/hal_lld_type2.h
@@ -405,20 +405,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32F7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F7xx/hal_lld.c
@@ -64,6 +64,7 @@ static void hal_lld_backup_domain_init(void) {
   }
 
 #if STM32_LSE_ENABLED
+  int rusefiLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -71,8 +72,10 @@ static void hal_lld_backup_domain_init(void) {
   /* No LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
-  while ((RCC->BDCR & RCC_BDCR_LSERDY) == 0)
-    ;                                       /* Waits until LSE is stable.   */
+  /* Waits until LSE is stable or times out. */
+  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+      && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
+    ;
 #endif
 
 #if HAL_USE_RTC
@@ -80,7 +83,11 @@ static void hal_lld_backup_domain_init(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+#if STM32_LSE_ENABLED
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+#else
     RCC->BDCR |= STM32_RTCSEL;
+#endif
 
     /* RTC clock enabled.*/
     RCC->BDCR |= RCC_BDCR_RTCEN;

--- a/os/hal/ports/STM32/STM32F7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F7xx/hal_lld.c
@@ -64,7 +64,7 @@ static void hal_lld_backup_domain_init(void) {
   }
 
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -73,7 +73,7 @@ static void hal_lld_backup_domain_init(void) {
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
   /* Waits until LSE is stable or times out. */
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
     ;
 #endif
@@ -84,7 +84,7 @@ static void hal_lld_backup_domain_init(void) {
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32F7xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F7xx/hal_lld.h
@@ -544,20 +544,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32F7xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32F7xx/hal_lld.h
@@ -542,6 +542,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   USB/SDIO clock setting.
  */
 #if !defined(STM32_CLOCK48_REQUIRED) || defined(__DOXYGEN__)

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.c
@@ -68,6 +68,7 @@ static inline void init_bkp_domain(void) {
   }
 
 #if STM32_LSE_ENABLED
+  int rusefiLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -75,8 +76,10 @@ static inline void init_bkp_domain(void) {
   /* No LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
-  while ((RCC->BDCR & RCC_BDCR_LSERDY) == 0)
-    ;                                       /* Waits until LSE is stable.   */
+  /* Waits until LSE is stable or times out. */
+  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+      && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
+    ;
 #endif
 
 #if HAL_USE_RTC
@@ -84,7 +87,11 @@ static inline void init_bkp_domain(void) {
      initialization.*/
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
+#if STM32_LSE_ENABLED
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+#else
     RCC->BDCR |= STM32_RTCSEL;
+#endif
 
     /* RTC clock enabled.*/
     RCC->BDCR |= RCC_BDCR_RTCEN;

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.c
@@ -68,7 +68,7 @@ static inline void init_bkp_domain(void) {
   }
 
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
 #if defined(STM32_LSE_BYPASS)
   /* LSE Bypass.*/
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON | RCC_BDCR_LSEBYP;
@@ -77,7 +77,7 @@ static inline void init_bkp_domain(void) {
   RCC->BDCR |= STM32_LSEDRV | RCC_BDCR_LSEON;
 #endif
   /* Waits until LSE is stable or times out. */
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->BDCR & RCC_BDCR_LSERDY) == 0)
     ;
 #endif
@@ -88,7 +88,7 @@ static inline void init_bkp_domain(void) {
   if ((RCC->BDCR & RCC_BDCR_RTCEN) == 0) {
     /* Selects clock source.*/
 #if STM32_LSE_ENABLED
-    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->BDCR |= (RCC->BDCR & RCC_BDCR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->BDCR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld_type1.h
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld_type1.h
@@ -663,6 +663,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   HSI divider.
  */
 #if !defined(STM32_HSIDIV) || defined(__DOXYGEN__)

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld_type1.h
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld_type1.h
@@ -665,20 +665,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld_type2.h
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld_type2.h
@@ -627,20 +627,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld_type2.h
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld_type2.h
@@ -625,6 +625,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   HSI divider.
  */
 #if !defined(STM32_HSIDIV) || defined(__DOXYGEN__)

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld_type3.h
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld_type3.h
@@ -635,6 +635,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   HSI divider.
  */
 #if !defined(STM32_HSIDIV) || defined(__DOXYGEN__)

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld_type3.h
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld_type3.h
@@ -637,20 +637,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32L0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L0xx/hal_lld.c
@@ -63,9 +63,12 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
+  int rusefiLseCounter = 0;
   RCC->CSR |= RCC_CSR_LSEON;
-  while ((RCC->CSR & RCC_CSR_LSERDY) == 0)
-    ;                                       /* Waits until LSE is stable.   */
+  /* Waits until LSE is stable or times out. */
+  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+      && (RCC->CSR & RCC_CSR_LSERDY) == 0)
+    ;
 #endif
 
 #if STM32_RTCSEL != STM32_RTCSEL_NOCLOCK
@@ -74,6 +77,11 @@ static void hal_lld_backup_domain_init(void) {
   if ((RCC->CSR & RCC_CSR_RTCEN) == 0) {
     /* Selects clock source.*/
     RCC->CSR |= STM32_RTCSEL;
+#if STM32_LSE_ENABLED
+    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+#else
+    RCC->CSR |= STM32_RTCSEL;
+#endif
 
     /* RTC clock enabled.*/
     RCC->CSR |= RCC_CSR_RTCEN;

--- a/os/hal/ports/STM32/STM32L0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L0xx/hal_lld.c
@@ -63,10 +63,10 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
   RCC->CSR |= RCC_CSR_LSEON;
   /* Waits until LSE is stable or times out. */
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->CSR & RCC_CSR_LSERDY) == 0)
     ;
 #endif
@@ -78,7 +78,7 @@ static void hal_lld_backup_domain_init(void) {
     /* Selects clock source.*/
     RCC->CSR |= STM32_RTCSEL;
 #if STM32_LSE_ENABLED
-    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->CSR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32L0xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32L0xx/hal_lld.h
@@ -371,6 +371,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   ADC clock setting.
  */
 #if !defined(STM32_ADC_CLOCK_ENABLED) || defined(__DOXYGEN__)

--- a/os/hal/ports/STM32/STM32L0xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32L0xx/hal_lld.h
@@ -373,20 +373,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**

--- a/os/hal/ports/STM32/STM32L1xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L1xx/hal_lld.c
@@ -65,10 +65,10 @@ static void hal_lld_backup_domain_init(void) {
 
   /* If enabled then the LSE is started.*/
 #if STM32_LSE_ENABLED
-  int rusefiLseCounter = 0;
+  int fomeLseCounter = 0;
   /* Waits until LSE is stable or times out. */
   RCC->CSR |= RCC_CSR_LSEON;
-  while ((!RUSEFI_STM32_LSE_WAIT_MAX || rusefiLseCounter++ < RUSEFI_STM32_LSE_WAIT_MAX)
+  while ((!FOME_STM32_LSE_WAIT_MAX || fomeLseCounter++ < FOME_STM32_LSE_WAIT_MAX)
       && (RCC->CSR & RCC_CSR_LSERDY) == 0)
     ;
 #endif
@@ -79,7 +79,7 @@ static void hal_lld_backup_domain_init(void) {
   if ((RCC->CSR & RCC_CSR_RTCEN) == 0) {
     /* Selects clock source.*/
 #if STM32_LSE_ENABLED
-    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) == 0 ? RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
+    RCC->CSR |= (RCC->CSR & RCC_CSR_LSERDY) == 0 ? FOME_STM32_LSE_WAIT_MAX_RTCSEL : STM32_RTCSEL;
 #else
     RCC->CSR |= STM32_RTCSEL;
 #endif

--- a/os/hal/ports/STM32/STM32L1xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32L1xx/hal_lld.h
@@ -267,6 +267,25 @@
 #endif
 
 /**
+ * @brief   Number of times to busy-loop waiting for LSE clock source.
+ * @note    The default value of 0 disables this behavior.
+ * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#endif
+
+/**
+ * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
+ * @note    If waiting for the LSE clock source times out due to
+ *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          fallback to another.
+ */
+#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#endif
+
+/**
  * @brief   ADC clock setting.
  */
 #if !defined(STM32_ADC_CLOCK_ENABLED) || defined(__DOXYGEN__)

--- a/os/hal/ports/STM32/STM32L1xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32L1xx/hal_lld.h
@@ -269,20 +269,20 @@
 /**
  * @brief   Number of times to busy-loop waiting for LSE clock source.
  * @note    The default value of 0 disables this behavior.
- * @note    See also RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL.
+ * @note    See also FOME_STM32_LSE_WAIT_MAX_RTCSEL.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX           0
+#if !defined(FOME_STM32_LSE_WAIT_MAX) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX           0
 #endif
 
 /**
  * @brief   Fallback RTC clock source if stopped waiting for LSE clock source.
  * @note    If waiting for the LSE clock source times out due to
- *          RUSEFI_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
+ *          FOME_STM32_LSE_WAIT_MAX, this allows the RTC clock source to
  *          fallback to another.
  */
-#if !defined(RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
-#define RUSEFI_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
+#if !defined(FOME_STM32_LSE_WAIT_MAX_RTCSEL) || defined(__DOXYGEN__)
+#define FOME_STM32_LSE_WAIT_MAX_RTCSEL    STM32_RTCSEL_LSE
 #endif
 
 /**


### PR DESCRIPTION
ported bfbf88e98b05e8648b6c140c0135508f63f9095b to stable FOME branch; I have not tested this

- H7 HAL was split into three types
- [some] Gx and Lx were dropped as they no longer (seem) to have the relevant logic; they are not current targets of FOME so I skipped digging deeper to see if they were moved etc.