### PR TITLE
stable_21.11.x.FOME: backup domain reset re: FOME_STM32_LSE_MAX_WAIT

### DIFF
--- a/os/hal/ports/STM32/STM32F0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F0xx/hal_lld.c
@@ -60,7 +60,15 @@ static void hal_lld_backup_domain_init(void) {
   PWR->CR |= PWR_CR_DBP;
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->BDCR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;

--- a/os/hal/ports/STM32/STM32F1xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F1xx/hal_lld.c
@@ -58,7 +58,15 @@ static void hal_lld_backup_domain_init(void) {
 
 #if HAL_USE_RTC
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->BDCR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;

--- a/os/hal/ports/STM32/STM32F37x/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F37x/hal_lld.c
@@ -57,7 +57,15 @@ static void hal_lld_backup_domain_init(void) {
   PWR->CR |= PWR_CR_DBP;
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->BDCR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;

--- a/os/hal/ports/STM32/STM32F3xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F3xx/hal_lld.c
@@ -57,7 +57,15 @@ static void hal_lld_backup_domain_init(void) {
   PWR->CR |= PWR_CR_DBP;
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->BDCR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;

--- a/os/hal/ports/STM32/STM32F4xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F4xx/hal_lld.c
@@ -57,7 +57,15 @@ static void hal_lld_backup_domain_init(void) {
   PWR->CR |= PWR_CR_DBP;
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->BDCR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;

--- a/os/hal/ports/STM32/STM32F7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32F7xx/hal_lld.c
@@ -57,7 +57,15 @@ static void hal_lld_backup_domain_init(void) {
   PWR->CR1 |= PWR_CR1_DBP;
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->BDCR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;

--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.c
@@ -61,7 +61,15 @@ static inline void init_bkp_domain(void) {
   PWR->CR1 |= PWR_CR1_DBP;
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->BDCR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->BDCR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->BDCR = RCC_BDCR_BDRST;
     RCC->BDCR = 0;

--- a/os/hal/ports/STM32/STM32L0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L0xx/hal_lld.c
@@ -55,7 +55,15 @@ static void hal_lld_backup_domain_init(void) {
   PWR->CR |= PWR_CR_DBP;
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->CSR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->CSR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->CSR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->CSR |= RCC_CSR_RTCRST;
     RCC->CSR &= ~RCC_CSR_RTCRST;

--- a/os/hal/ports/STM32/STM32L1xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32L1xx/hal_lld.c
@@ -57,7 +57,15 @@ static void hal_lld_backup_domain_init(void) {
   PWR->CR |= PWR_CR_DBP;
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->CSR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
+  if (
+#if STM32_LSE_ENABLED
+      (
+       fomeLseCounter >= FOME_STM32_LSE_MAX_WAIT
+       && (RCC->CSR & STM32_RTCSEL_MASK) != FOME_STM32_LSE_WAIT_MAX_RTCSEL
+      ) || fomeLseCounter < FOME_STM32_LSE_MAX_WAIT
+      &&
+#endif
+      (RCC->CSR & STM32_RTCSEL_MASK) != STM32_RTCSEL) {
     /* Backup domain reset.*/
     RCC->CSR |= RCC_CSR_RTCRST;
     RCC->CSR &= ~RCC_CSR_RTCRST;


### PR DESCRIPTION
also consider that the RTCSEL might have fallen back to the FOME_STM32_LSE_MAX_WAIT_RTCSEL when checking for backup domain reset

https://github.com/rusefi/ChibiOS/pull/52